### PR TITLE
Bug Fix: Retaining Previous LeetCode Question

### DIFF
--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -5,14 +5,13 @@ import Query from './components/Query';
 
 interface ResponseProps {
   submitElement: Element;
-  inputQuestion: string;
   inputElement: Element;
   topics: string[];
   triggerMode: TriggerMode;
 }
 
 const App: FC<ResponseProps> = (props) => {
-  const { submitElement, inputQuestion, inputElement, topics, triggerMode } = props;
+  const { submitElement, inputElement, topics, triggerMode } = props;
   const [currentQuestion, setCurrentQuestion] = useState('');
 
   const updateQuestion = useCallback(
@@ -20,15 +19,15 @@ const App: FC<ResponseProps> = (props) => {
       const currText = inputElement.textContent;
       if (currText) {
         const petitionOpts: IPetition = {
-          question: inputQuestion,
           solution: currText,
           mode: mode,
+          triggerMode: triggerMode,
         };
         const newQuestion = addPetition(petitionOpts);
         setCurrentQuestion(newQuestion);
       }
     },
-    [inputQuestion, inputElement]
+    [inputElement, triggerMode]
   );
 
   console.debug('GGGG00-----', topics);

--- a/src/contentScript/index.tsx
+++ b/src/contentScript/index.tsx
@@ -21,14 +21,13 @@ import './styles.scss';
 interface IMountArg {
   trigger: TriggerMode;
   engCfg: Engine;
-  inpQ?: string;
   solutionElem: Element;
   submitElem?: Element;
   topics: string[];
 }
 
 const mount = (arg: IMountArg) => {
-  const { trigger, engCfg, inpQ, solutionElem, submitElem, topics } = arg;
+  const { trigger, engCfg, solutionElem, submitElem, topics } = arg;
   let container = document.getElementsByClassName('chat-gpt-container')[0];
   if (!container) {
     container = document.createElement('div');
@@ -56,13 +55,7 @@ const mount = (arg: IMountArg) => {
   const responseComponent = (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <App
-        submitElement={submitElem!}
-        inputQuestion={inpQ!.replace(/\n{3,}/g, '\n\n')}
-        inputElement={solutionElem}
-        topics={topics}
-        triggerMode={trigger}
-      />
+      <App submitElement={submitElem!} inputElement={solutionElem} topics={topics} triggerMode={trigger} />
     </ThemeProvider>
   );
 
@@ -110,7 +103,6 @@ const run = () => {
     mount({
       trigger: tMode,
       engCfg: engCfg,
-      inpQ: inputQuestion.textContent!,
       solutionElem: inputSolution,
       submitElem: buttonSubmit,
       topics: inputTopics,
@@ -133,7 +125,6 @@ const mutationObserver = new MutationObserver((mutations) => {
     mount({
       trigger: tMode,
       engCfg: engCfg,
-      inpQ: inputQuestion.textContent!,
       solutionElem: inputSolution,
       submitElem: buttonSubmit,
       topics: inputTopics,

--- a/src/interfaces/petition.ts
+++ b/src/interfaces/petition.ts
@@ -1,5 +1,7 @@
+import { TriggerMode } from './client';
+
 export interface IPetition {
-  question: string;
   solution: string;
   mode?: string;
+  triggerMode: TriggerMode;
 }

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -32,25 +32,6 @@ export const getAppVersion = () => Browser.runtime.getManifest().version;
 
 export const getReminderMessage = () => REMINDER_MESSAGES[Math.floor(Math.random() * REMINDER_MESSAGES.length)];
 
-export const addPetition = (opts: IPetition): string => {
-  const { question, solution, mode } = opts;
-  const langBasedAppStrings = loadAppLocales();
-
-  if (mode) {
-    if (mode === langBasedAppStrings.appBruteforce) {
-      // bruteforce
-      return PREFIX_PETITION + PETITION_QUESTION + question + M_B_PETITION_SOLUTION + solution;
-    }
-
-    if (mode === langBasedAppStrings.appOptimize) {
-      // optmize
-      return PREFIX_PETITION + PETITION_QUESTION + question + M_O_PETITION_SOLUTION + solution;
-    }
-  }
-
-  return PREFIX_PETITION + PETITION_QUESTION + question + PETITION_SOLUTION + solution;
-};
-
 export const formatTopicQuery = (topic: string): string => PETITION_TOPIC_QUERY + topic + PETITION_TOPIC_QUERY_EOL;
 
 export function querySelectElement<T extends Element>(possibleItems: string[]): T | undefined {
@@ -168,4 +149,33 @@ export const retryHolderElement = (tMode: TriggerMode) => {
     sElem?.getElementsByClassName(cfg.appendContainerLeft[1])[0];
 
   return sChild;
+};
+
+export const prettifyQuestion = (question: string) => question.replace(/\n{3,}/g, '\n\n');
+
+export const getQuestionText = (tMode: TriggerMode) => {
+  const qChild = getQuestionElement(tMode);
+  if (qChild) return prettifyQuestion(qChild.textContent!);
+
+  return '';
+};
+
+export const addPetition = (opts: IPetition): string => {
+  const { solution, mode, triggerMode } = opts;
+  const question = getQuestionText(triggerMode);
+  const langBasedAppStrings = loadAppLocales();
+
+  if (mode) {
+    if (mode === langBasedAppStrings.appBruteforce) {
+      // bruteforce
+      return PREFIX_PETITION + PETITION_QUESTION + question + M_B_PETITION_SOLUTION + solution;
+    }
+
+    if (mode === langBasedAppStrings.appOptimize) {
+      // optmize
+      return PREFIX_PETITION + PETITION_QUESTION + question + M_O_PETITION_SOLUTION + solution;
+    }
+  }
+
+  return PREFIX_PETITION + PETITION_QUESTION + question + PETITION_SOLUTION + solution;
 };


### PR DESCRIPTION
### Issue
Currently, extension retains the previous LeetCode question when users progress from one problem to the next in their study plan. The incorrect question is sent to ChatGPT, causing confusion and an inaccurate interaction.

![image](https://github.com/Liopun/leet-chatgpt-extension/assets/5084613/09d1272c-f0f7-48a1-b91e-fa70dbac0dbb)
On screenshot it visible, that extension use not current question

### Changes Made
Retrieve the LeetCode question element right before the request is made to ChatGPT, ensuring that the extension captures the correct, up-to-date information for the current problem.

